### PR TITLE
github actions: test creating html pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,25 @@
+name: CI
+
+# only build on push to master
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    # use a premade container with R tools, ubuntu 18:04 (ubuntu-latest)
+    # doesn't have r-cran packages and installing them from apt or from c-ran
+    # is too slow
+    container:
+      image: rocker/tidyverse:latest
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: compile all Rmd to htmls
+      run: make
+
+# TODO: publish on gh-pages

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+# helper function: recursively find files
+rwildcard=$(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2) $(filter $(subst *,%,$2),$d))
+
+SRCDIR  := $(PWD)
+SOURCES := $(call rwildcard,$(SRCDIR),*.Rmd)
+HTMLS   := $(SOURCES:%.Rmd=%.html)
+FILES   := $(SOURCES:%.Rmd=%_files)
+
+TARGETS = $(HTMLS) $(FILES)
+
+all: $(HTMLS)
+
+deps:
+	# this should probably handle comments in the file
+	Rscript -e 'install.packages(read.table("Rdependencies")[,1])'
+
+%.html : %.Rmd
+	Rscript -e "rmarkdown::render('$<')"
+
+
+clean:
+	rm -rf $(TARGETS)
+
+.PHONY: clean deps

--- a/Rdependencies
+++ b/Rdependencies
@@ -1,0 +1,1 @@
+rmarkdown


### PR DESCRIPTION
~work in progress - don't merge.~

This change introduces:
* a `Makefile` containing common commands
* `Rdependencies` file with all the R packages that are required by this project
* `.github/workflows/main.yml` is the configuration for Github Actions

Makefile targets:
* `make deps` - will install the R packages listed in `Rdependencies`
* `make all` - will compile all the `.Rmd` files to `.html`
* `make clean` - will remove all the `.html` files
* TODO: `make dist` - to create an artifact for a website